### PR TITLE
fix(exotic-encoding): reject dns resolutions with exotic encodings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
     es6: true,
   },
   extends: [
-    'algolia',
+    'algolia/jest',
   ],
   globals: {
     Atomics: 'readonly',
@@ -24,7 +24,5 @@ module.exports = {
         extensions: [".js", ".ts"]
       }
     }
-  },
-  rules: {
   },
 };

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "@semantic-release/changelog": "^3.0.4",
     "@semantic-release/git": "^7.0.16",
+    "@types/ip-address": "^5.8.2",
     "@types/jest": "^24.0.19",
     "@types/node": "^12.11.1",
     "@typescript-eslint/eslint-plugin": "^2.4.0",
@@ -40,5 +41,8 @@
     "semantic-release": "^15.13.27",
     "ts-jest": "^24.1.0",
     "typescript": "^3.6.4"
+  },
+  "dependencies": {
+    "ip-address": "^6.1.0"
   }
 }

--- a/src/dns.test.ts
+++ b/src/dns.test.ts
@@ -1,0 +1,49 @@
+import { validateURL, DNSResolveError } from './index';
+import { lookup } from 'dns';
+
+jest.mock('dns');
+
+// this test suite describe scenarios where the attacker controls the DNS
+// server for a particular request and returns ip addresses in uncommon
+// encodings which are supported by the underlying network library
+describe('dns attacks', () => {
+  it('should reject on hex encoding', async () => {
+    // @ts-ignore
+    lookup.mockImplementation((...args) => {
+      const cb = args.pop(); // last argument of lookup is callback
+      cb(null, { address: '0x7f.0x0.0x0.0x1', family: 4 });
+    });
+    const url = 'http://127.0.0.1/';
+    await expect(validateURL({ url })).rejects.toBeInstanceOf(DNSResolveError);
+  });
+
+  it('should reject on octal encoding', async () => {
+    // @ts-ignore
+    lookup.mockImplementation((...args) => {
+      const cb = args.pop(); // last argument of lookup is callback
+      cb(null, { address: '0177.0.0.01', family: 4 });
+    });
+    const url = 'http://127.0.0.1/';
+    await expect(validateURL({ url })).rejects.toBeInstanceOf(DNSResolveError);
+  });
+
+  it('should reject on dword encoding', async () => {
+    // @ts-ignore
+    lookup.mockImplementation((...args) => {
+      const cb = args.pop(); // last argument of lookup is callback
+      cb(null, { address: '2130706433', family: 4 });
+    });
+    const url = 'http://127.0.0.1/';
+    await expect(validateURL({ url })).rejects.toBeInstanceOf(DNSResolveError);
+  });
+
+  it('should reject on mixed encoding', async () => {
+    // @ts-ignore
+    lookup.mockImplementation((...args) => {
+      const cb = args.pop(); // last argument of lookup is callback
+      cb(null, { address: '0177.0.0.0x1', family: 4 });
+    });
+    const url = 'http://127.0.0.1/';
+    await expect(validateURL({ url })).rejects.toBeInstanceOf(DNSResolveError);
+  });
+});

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,8 @@
 import {
-  validateURL, MalformedURLError, DNSResolveError, BlacklistedIPError,
+  validateURL,
+  MalformedURLError,
+  DNSResolveError,
+  BlacklistedIPError,
 } from './index';
 
 describe('validateURL', () => {
@@ -11,7 +14,9 @@ describe('validateURL', () => {
   it('should throw a MalformedURLError on malformed urls', async () => {
     const url = 'someMalformedURL';
 
-    await expect(validateURL({ url })).rejects.toBeInstanceOf(MalformedURLError);
+    await expect(validateURL({ url })).rejects.toBeInstanceOf(
+      MalformedURLError
+    );
   });
 
   it('should throw a DNSResolveError on non-existing urls', async () => {
@@ -20,8 +25,10 @@ describe('validateURL', () => {
     await expect(validateURL({ url })).rejects.toBeInstanceOf(DNSResolveError);
   });
 
-  it('should throw a generic error, but report a precise one on blacklisted IP', async () => {
+  it('should throw a blacklisted IP Error', async () => {
     const url = 'http://10.0.0.0/';
-    await expect(validateURL({ url })).rejects.toBeInstanceOf(BlacklistedIPError);
+    await expect(validateURL({ url })).rejects.toBeInstanceOf(
+      BlacklistedIPError
+    );
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,46 +1,14 @@
 import { lookup } from 'dns';
 import { URL } from 'url';
 import { promisify } from 'util';
-import { BlacklistedIPError, DNSResolveError, MalformedURLError } from './errors';
+import { Address6, Address4 } from 'ip-address';
+import {
+  BlacklistedIPError,
+  DNSResolveError,
+  MalformedURLError,
+} from './errors';
 
 const dnsLookupPromisified = promisify(lookup);
-
-const createBlacklistedIPError = <T extends Record<string, any>>(url: string, restrictedIP: string, context?: T): BlacklistedIPError<T> & T => new BlacklistedIPError(url, restrictedIP, context) as BlacklistedIPError<T> & T;
-
-interface ValidationParams<T extends Record<string, any>> {
-  url: string;
-  context?: T;
-  ipPrefixes?: string[];
-}
-
-export async function validateURL<T extends Record<string, any>>({ url, ipPrefixes = PRIVATE_IP_PREFIXES, context }: ValidationParams<T>) {
-  let parsedURL: URL;
-  try {
-    parsedURL = new URL(url);
-  } catch (e) {
-    throw new MalformedURLError(url);
-  }
-
-  const { hostname } = parsedURL;
-
-  let ip: string;
-  try {
-    const { address } = await dnsLookupPromisified(hostname);
-    // I don't believe this can happen, but just in case
-    if (typeof address !== 'string' || address.length === 0) {
-      throw new Error('Invalid address');
-    }
-    ip = address;
-  } catch (err) {
-    throw new DNSResolveError(err);
-  }
-
-  if (isRestrictedIP(ip, ipPrefixes)) {
-    throw createBlacklistedIPError<T>(url, ip, context);
-  }
-
-  return true;
-}
 
 // https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html
 // https://en.wikipedia.org/wiki/Private_network
@@ -75,7 +43,70 @@ export const PRIVATE_IP_PREFIXES = [
   '::1',
 ];
 
-function isRestrictedIP(ip: string, ipPrefixes: string[] = PRIVATE_IP_PREFIXES) {
+const createBlacklistedIPError = <T extends Record<string, any>>(
+  url: string,
+  restrictedIP: string,
+  context?: T
+): BlacklistedIPError<T> & T => {
+  return new BlacklistedIPError(
+    url,
+    restrictedIP,
+    context
+  ) as BlacklistedIPError<T> & T;
+};
+
+interface ValidationParams<T extends Record<string, any>> {
+  url: string;
+  context?: T;
+  ipPrefixes?: string[];
+}
+
+export async function validateURL<T extends Record<string, any>>({
+  url,
+  ipPrefixes = PRIVATE_IP_PREFIXES,
+  context,
+}: ValidationParams<T>) {
+  let parsedURL: URL;
+  try {
+    parsedURL = new URL(url);
+  } catch (e) {
+    throw new MalformedURLError(url);
+  }
+
+  const { hostname } = parsedURL;
+
+  let ip: string;
+  try {
+    const res = await dnsLookupPromisified(hostname);
+    const { address, family } = res;
+    // I don't believe this can happen, but just in case
+    if (typeof address !== 'string' || address.length === 0) {
+      throw new Error('Invalid address');
+    }
+
+    const formattedIP =
+      family === 4 ? new Address4(address) : new Address6(address);
+
+    if (!formattedIP.isValid()) {
+      throw new Error('Invalid address');
+    }
+
+    ip = formattedIP.correctForm();
+  } catch (err) {
+    throw new DNSResolveError(err);
+  }
+
+  if (isRestrictedIP(ip, ipPrefixes)) {
+    throw createBlacklistedIPError<T>(url, ip, context);
+  }
+
+  return true;
+}
+
+function isRestrictedIP(
+  ip: string,
+  ipPrefixes: string[] = PRIVATE_IP_PREFIXES
+) {
   const sanitizedIP = ip.trim().toLowerCase();
   const matchesPrefix = (prefix: string) => sanitizedIP.startsWith(prefix);
   return ipPrefixes.some(matchesPrefix);

--- a/yarn.lock
+++ b/yarn.lock
@@ -504,6 +504,13 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
+"@types/ip-address@^5.8.2":
+  version "5.8.2"
+  resolved "https://registry.yarnpkg.com/@types/ip-address/-/ip-address-5.8.2.tgz#5e413c477f78b3a264745eac937538a6e6e0c1f6"
+  integrity sha512-LFlDGRjJDnahfPyNCZGXvlaevSmZTi/zDxjTdXeTs8TQ9pQkNZKbCWaJXW29a3bGPRsASqeO+jGgZlaTUi9jTw==
+  dependencies:
+    "@types/jsbn" "*"
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"
@@ -535,6 +542,11 @@
   integrity sha512-YYiqfSjocv7lk5H/T+v5MjATYjaTMsUkbDnjGqSMoO88jWdtJXJV4ST/7DKZcoMHMBvB2SeSfyOzZfkxXHR5xg==
   dependencies:
     "@types/jest-diff" "*"
+
+"@types/jsbn@*":
+  version "1.2.29"
+  resolved "https://registry.yarnpkg.com/@types/jsbn/-/jsbn-1.2.29.tgz#28229bc0262c704a1506c3ed69a7d7e115bd7832"
+  integrity sha512-2dVz9LTEGWVj9Ov9zaDnpvqHFV+W4bXtU0EUEGAzWfdRNO3dlUuosdHpENI6/oQW+Kejn0hAjk6P/czs9h/hvg==
 
 "@types/json-schema@^7.0.3":
   version "7.0.3"
@@ -3038,6 +3050,15 @@ invert-kv@^2.0.0:
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
   integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
 
+ip-address@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-6.1.0.tgz#3c3335bc90f22b3545a6eca5bffefabeb2ea6fd2"
+  integrity sha512-u9YYtb1p2fWSbzpKmZ/b3QXWA+diRYPxc2c4y5lFB/MMk5WZ7wNZv8S3CFcIGVJ5XtlaCAl/FQy/D3eQ2XtdOA==
+  dependencies:
+    jsbn "1.1.0"
+    lodash "^4.17.15"
+    sprintf-js "1.1.2"
+
 ip-regex@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
@@ -3769,6 +3790,11 @@ js-yaml@^3.13.1:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+jsbn@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-1.1.0.tgz#b01307cb29b618a1ed26ec79e911f803c4da0040"
+  integrity sha1-sBMHyym2GKHtJux56RH4A8TaAEA=
 
 jsbn@~0.1.0:
   version "0.1.1"
@@ -6414,6 +6440,11 @@ split@^1.0.0:
   integrity sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==
   dependencies:
     through "2"
+
+sprintf-js@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.2.tgz#da1765262bf8c0f571749f2ad6c26300207ae673"
+  integrity sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==
 
 sprintf-js@~1.0.2:
   version "1.0.3"


### PR DESCRIPTION
This PR fixes a vulnerability whereby the attacker could leverage his control over a DNS server to return IP addresses in exotic encodings such as octal, hex, or dword, or even mixed, which can be parsed by the underlying network layer.