### PR TITLE
chore: update renovate reviewers

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,6 @@
     "algolia",
     ":prHourlyLimitNone"
   ],
-  "reviewers": ["JonathanMontane","Jerska"],
+  "reviewers": ["Jerska", "sbellone", "bodinsamuel"],
   "semanticCommitType": "chore"
 }


### PR DESCRIPTION
@JonathanMontane Although you're the one behind this repo, there no reason you should still be pinged about dependency updates on it.
Switching the reviewers.